### PR TITLE
Update raspi-blinka.py

### DIFF
--- a/raspi-blinka.py
+++ b/raspi-blinka.py
@@ -105,7 +105,7 @@ Raspberry Pi and installs Blinka
         default_python = 0
         if not shell.prompt("Continue?"):
             shell.exit()
-    elif default_python_version() < 3:
+    elif int(default_python_version()) < 3:
         shell.warn("WARNING Default System python version is {}. It will be updated to Version 3.".format(default_python_version(False)))
         default_python = 2
         if not shell.prompt("Continue?"):


### PR DESCRIPTION
fixes a "< operator cannot be used to compare NonType with int" error on a RPI-Zero-W

https://github.com/BasdeWinter/Raspberry-Pi-Installer-Scripts/commit/d262dedd1f9c632f7980001c395111c547d3a012